### PR TITLE
TAI-28: Fixed focus overriden issue on header

### DIFF
--- a/paragon/_discussion.scss
+++ b/paragon/_discussion.scss
@@ -28,23 +28,23 @@ position: static;
     display: block !important;
     }
     .nav-button-group {
-    border: 1px solid #E5E7EB;
-    border-radius: 6px;
     padding: 0 !important;
-    overflow: hidden;
     @include media-breakpoint-down(sm) {
         margin: 0 0 10px;
     }
     .nav-item {
         &:first-child {
-        .nav-link {
-            border-left: none !important;
+            .nav-link {
+                border-radius: 6px 0 0 6px !important;
+            }
         }
+        &:last-child {
+            .nav-link {
+                border-radius: 0 6px 6px 0 !important;
+            }
         }
         .nav-link {
-        border: none;
         border-radius: 0 !important;
-        border-left: 1px solid #E5E7EB !important;
         font-size: 14px;
         line-height: 20px;
         font-weight: 500;
@@ -54,6 +54,10 @@ position: static;
         }
         &:hover {
             background: $primary-light !important;
+        }
+        &:focus {
+            position: relative;
+            z-index: 1;
         }
         &.active {
             background: $primary !important;


### PR DESCRIPTION
**Description:**
**Issue:** https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/28
**Before:**
The keyboard focus was minimal and not a clear indication of a focused element.
![image](https://github.com/user-attachments/assets/7ba438a8-e26f-4059-9206-0e8fdec6cd15)

**After:**
The keyboard focus is clear on focused element.
<img width="801" alt="Screenshot 2025-04-15 at 4 57 26 PM" src="https://github.com/user-attachments/assets/d246cc89-cef6-4689-8620-78a5fc2ea61a" />
