### PR TITLE
Appears the focus on the theme toggle button

### DIFF
--- a/paragon/_extras.scss
+++ b/paragon/_extras.scss
@@ -30,6 +30,13 @@
                 opacity: 0;
                 width: 0;
                 height: 0;
+
+                &:focus {
+                  ~ .slider {
+                    outline: 2px solid $primary;
+                    outline-offset: 1px;
+                  }
+                }
             }
 
             /* The slider */

--- a/paragon/_header.scss
+++ b/paragon/_header.scss
@@ -320,7 +320,6 @@
             border: none !important;
             padding: 9px 15px !important;
             box-shadow: none !important;
-            outline: none !important;
             background: $primary-light !important;
             color: $primary;
             font-size: 14px;

--- a/themes/dark/_extras.scss
+++ b/themes/dark/_extras.scss
@@ -1471,6 +1471,13 @@ section[data-testid=sidebar-NOTIFICATIONS], section[data-testid=sidebar-DISCUSSI
     }
     .toggle-switch {
         .switch {
+            input {
+                &:focus {
+                  ~ .slider {
+                    outline-color: #ccc;
+                  }
+                }
+              }
             /* The slider */
             .slider {
                 background-color: #ccc;


### PR DESCRIPTION
### Description

This pull request resolves several accessibility issues in the Tutor Indigo theme that were identified during a recent accessibility review. These updates aim to improve usability for all users, especially those relying on assistive technologies. The changes also help ensure compliance with recognized accessibility standards, such as the Web Content Accessibility Guidelines (WCAG) 2.1.

For further details, please refer to the related issue: [overhangio/tutor-indigo#146](https://github.com/overhangio/tutor-indigo/issues/146).

---

### Accessibility Fixes Implemented


#### Focus on the Theme Toggle Button

The theme toggle button lacked a visible focus indicator for keyboard users. This has been addressed by ensuring a clear focus style is applied.

- **Code Commit:** [Appears the focus on the theme toggle button](https://github.com/edly-io/brand-openedx/commit/b08e3b72d22626d5959f8df58212c1101e7d70bd)
- **Issue:** [Taiga - US/139](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/139)
- **Live Example:** [Home Page](https://sandbox.openedx.edly.io/)
- **Linked Pull Requests:** [MFE Header](https://github.com/edly-io/frontend-component-header/pull/27 ) - [Tutor Indigo](https://github.com/overhangio/tutor-indigo/pull/147)

---

### Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report:  [Accessibility Audit](https://github.com/overhangio/tutor-indigo/issues/146)

