### PR TITLE
feat: increase focus visible thickness

### DIFF
--- a/paragon/_discussion.scss
+++ b/paragon/_discussion.scss
@@ -22,6 +22,7 @@ width: 100%;
 padding: 0 15px;
 box-shadow: none;
 position: static;
+z-index: 3 !important;
 .navbar {
     padding: 0 0 28px;
     @include media-breakpoint-down(sm) {

--- a/paragon/_discussion.scss
+++ b/paragon/_discussion.scss
@@ -29,42 +29,51 @@ z-index: 3 !important;
     display: block !important;
     }
     .nav-button-group {
-    border: 1px solid #E5E7EB;
-    border-radius: 6px;
     padding: 0 !important;
-    overflow: hidden;
     @include media-breakpoint-down(sm) {
         margin: 0 0 10px;
     }
     .nav-item {
-        &:first-child {
+        &:first-of-type {
+          .nav-link {
+            border-top-left-radius: 6px;
+            border-bottom-left-radius: 6px;
+          }
+        }
+        &:last-of-type {
+          .nav-link {
+            border-top-right-radius: 6px;
+            border-bottom-right-radius: 6px;
+          }
+        }
         .nav-link {
-            border-left: none !important;
-        }
-        }
-        .nav-link {
-        border: none;
-        border-radius: 0 !important;
-        border-left: 1px solid #E5E7EB !important;
-        font-size: 14px;
-        line-height: 20px;
-        font-weight: 500;
-        padding: 9px 17px;
-        @include media-breakpoint-down(sm) {
-            padding: 9px 12px;
-        }
-        &:hover {
-            background: $primary-light !important;
-        }
-        &.active {
-            background: $primary !important;
-        }
+          font-size: 14px;
+          line-height: 20px;
+          font-weight: 500;
+          padding: 9px 17px;
+          border-radius: 0;
+          border: 1px solid #E5E7EB;
+          margin-right: -1px;
+          @include media-breakpoint-down(sm) {
+              padding: 9px 12px;
+          }
+          &:hover {
+              background: $primary-light !important;
+          }
+          &.active {
+              background: $primary !important;
+          }
+          &:focus {
+              outline-offset: 3px;
+              position: relative;
+              z-index: 1;
+          }
         }
 
     }
     }
     .border-right.border-light-400.mx-3 {
-    display: none !important;
+      display: none !important;
     }
     .btn.btn-brand {
     padding: 9px 17px;
@@ -83,6 +92,10 @@ z-index: 3 !important;
     overflow: hidden;
     @include media-breakpoint-down(sm) {
         width: 100%;
+    }
+
+    &.has-focus {
+      outline: 2px auto -webkit-focus-ring-color;
     }
     &:after {
         display: none !important;
@@ -104,9 +117,9 @@ z-index: 3 !important;
             margin: 0 !important;
             padding: 0 0.75rem !important;
         }
+      }
     }
-    }
-}
+  }
 }
 .pgn__pageBanner__accentB {
 margin: 0 0 30px;

--- a/paragon/_header.scss
+++ b/paragon/_header.scss
@@ -331,9 +331,6 @@
                 padding: 0 !important;
                 background: none !important;
             }
-            &:before {
-                display: none;
-            }
             &:after {
                 border-color: $primary !important;
                 margin-left: 8px !important;

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -15,8 +15,10 @@ html {
     padding-left: 15px !important;
     padding-right: 15px !important;
 }
-#root .btn:before {
-    border-color: transparent !important;
+
+:focus,
+:focus-visible {
+    outline-width: 2px;
 }
 
 // detail page

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1,4 +1,5 @@
 $primary: #15376D;
+$brand: #15376D;
 $primary-light: #F2F7F8;
 $light-dark: #374151;
 $text-color: #111827;


### PR DESCRIPTION
### 📝 Description

This PR improves keyboard accessibility by updating the global focus styles to comply with **WCAG 2.4.11 – Focus Appearance (Minimum)**.

Previously, the focus indicators on interactive elements were only **1px thick**, which falls short of the minimum visibility requirements. The update ensures that:

- All focusable elements now have a clearly visible **2px focus outline**.
- Keyboard users can more easily identify which element is currently focused.

**Related issue:** [tutor-indigo/#146](https://github.com/overhangio/tutor-indigo/issues/146)  
**Taiga Task (if accessible):** [US 70 – Focus indicator thickness compliance](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/70)
**Related PR:** [tutor-indigo/#158](https://github.com/overhangio/tutor-indigo/pull/158)

---

### Related Issues on Taiga

1. [TIA-39 – Focus is not visible on add a post, cancel and submit button](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/39)
2. [TIA-44 – Focus visibility issue on Leaner Side page elements](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/44)
3. [TIA-50 – ocus visibility issue on Admin Side page elements](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/50)
5. [TIA-76 – Missing clear focus indicators on multiple page elements](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/76)
6. [TIA-87 – Learner-dashboard page: ( 2.4.7) Focus not visible for Explore courses button](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/87)
7. [TIA-28 – Discussion page: Focus is not visible on tabs for discussion](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/28)






### 🔧 Summary of Changes

- Improved focus styling for interactive buttons (e.g., “Add a Post”, “Cancel”, “Submit”, “Delete My Account”)  
- Enhanced focus visibility across learner and admin pages    
- Ensured tab focus visibility on the Discussion page tabs  

---

### 🧪 How Has This Been Tested?

- Manually tested using keyboard navigation (Tab/Shift+Tab) to confirm that the updated 2px outline is applied consistently.
- Verified that the visual focus remains unobtrusive but clearly visible across various UI components.

---

### 🖼️ Screenshots/Sandbox (optional):

**Live Preview:** [View Sandbox](https://apps.sandbox.openedx.edly.io/)

| Before | After |
|--------|-------|
| 1px thin focus outline | 2px thick focus outline |
| <img width="552" alt="image" src="https://github.com/user-attachments/assets/7102cf1c-7a26-447f-9270-0a30123f5307" /> | <img width="552" alt="image" src="https://github.com/user-attachments/assets/de50b6ac-86d9-4b17-a5e3-8c2ba2335269" /> |
| <img width="394" alt="image" src="https://github.com/user-attachments/assets/6a4a95b1-c6b5-405f-a727-2c1fb4a4e672" /> | <img width="394" alt="image" src="https://github.com/user-attachments/assets/e87a96bf-5922-430b-86ec-adefd66d24a6" /> |

---

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/4955b5c2-9b4f-4229-bd9f-59e5438ca416) ![image](https://github.com/user-attachments/assets/e948f607-de34-4f7b-8d4a-c553bc04d93e) ![image](https://github.com/user-attachments/assets/2e0e6440-7bb8-4cfb-aa4d-968b16dc6919) | ![image](https://github.com/user-attachments/assets/79555fe1-69cf-4f5d-9077-f746f23abbbd) ![image](https://github.com/user-attachments/assets/f057d49b-1651-46e2-8c47-4121606ab52d) ![image](https://github.com/user-attachments/assets/d3df358e-bebd-424d-b4db-c1c9388c2b6a)![image](https://github.com/user-attachments/assets/725e246f-31aa-4984-9206-b0367f7d1c9b) |

--- 

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/b95969e1-46c6-40a6-9be8-9578695829d9) | ![image](https://github.com/user-attachments/assets/f7e4e3a0-7c92-48ca-b3aa-6ee8dde497f7) | 

---

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/2dd55f72-0cd1-49a2-b51c-3b43556d4c9b) | ![image](https://github.com/user-attachments/assets/12f3b178-06eb-413e-9084-8eeef994413e) |


---

### 📄 Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report: [Accessibility Audit](https://github.com/overhangio/tutor-indigo/issues/146)
