### PR TITLE
fix: Made the alert-success styling explicit for learning mfe

### DIFF
--- a/paragon/_learning.scss
+++ b/paragon/_learning.scss
@@ -72,7 +72,7 @@
     .bg-light-400 {
         background: $primary-light !important;
     }
-    .row.w-100.mx-0.mb-4.border.border-light > .col-12 .alert.alert-success,
+    .row.w-100.border.border-light > .col-12 .alert.alert-success,
     .streak-modal .alert.alert-success {
         box-shadow: none;
         a {

--- a/paragon/_learning.scss
+++ b/paragon/_learning.scss
@@ -72,7 +72,8 @@
     .bg-light-400 {
         background: $primary-light !important;
     }
-    .alert.alert-success {
+    .row.w-100.mx-0.mb-4.border.border-light > .col-12 .alert.alert-success,
+    .streak-modal .alert.alert-success {
         box-shadow: none;
         a {
             background: #15376D;


### PR DESCRIPTION
The styling for Alert component with success variant was being picked from _learning.scss file which was disturbing other mfes styling like in authn mfe forgot password page. This PR makes the alert styling explicit to only learning mfe so it won't effect any other mfes as we have separate scss files for each mfe.