### PR TITLE
fix: Passing grade tooltip color contrast ratio

### DIFF
--- a/paragon/_progress.scss
+++ b/paragon/_progress.scss
@@ -108,7 +108,7 @@
             color: $text-color;
         }
         .donut-chart-label {
-            color: #4B5563;
+            color: $gray-700;
         }
     }
     .grade-bar .grade-bar__base {
@@ -168,15 +168,15 @@
     }
 }
 #minimum-grade-tooltip.bg-primary-500 {
-    background: #9CA3AF !important;
-    border-color: #9CA3AF !important;
+    background: $gray-700 !important;
+    border-color: $gray-700 !important;
     filter: none;
     .arrow {
         &:before {
-            border-bottom-color: #9CA3AF !important;
+            border-bottom-color: $gray-700 !important;
         }
         &:after {
-            border-bottom-color: #9CA3AF !important;
+            border-bottom-color: $gray-700 !important;
         }
     }
     .popover-body {

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -3,6 +3,7 @@ $primary-light: #F2F7F8;
 $light-dark: #374151;
 $text-color: #111827;
 $text-color-primary: #515661;
+$gray-700: #4b5563;
 $text-color-light: #515661;
 
 // for toggle theme button

--- a/themes/dark/_extras.scss
+++ b/themes/dark/_extras.scss
@@ -1099,15 +1099,15 @@ svg {
     }
 }
 #minimum-grade-tooltip.bg-primary-500 {
-    background: #9CA3AF !important;
-    border-color: #9CA3AF !important;
+    background: $gray-700 !important;
+    border-color: $gray-700 !important;
     filter: none;
     .arrow {
         &:before {
-            border-bottom-color: #9CA3AF !important;
+            border-bottom-color: $gray-700 !important;
         }
         &:after {
-            border-bottom-color: #9CA3AF !important;
+            border-bottom-color: $gray-700 !important;
         }
     }
     .popover-body {


### PR DESCRIPTION
### 📝 Description

This PR fixes a **color contrast issue** on the **Progress Page**, ensuring compliance with **WCAG 1.4.3 – Contrast (Minimum)**, which requires a minimum contrast ratio of **4.5:1** for normal text.

- **Progress Page – Failing Contrast for Passing Grade Text**  
  The **"50%" passing grade** text did not meet the required contrast ratio, especially under light themes or certain backgrounds. This affected readability for users with visual impairments or color blindness.

The text styling has been updated to meet the minimum contrast ratio, ensuring that all users can clearly perceive grade-related information.

**Related Epic:** [WCAG Compliance: Contrast and Sensory Characteristics](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/epic/6)  
**Taiga Task (if you have access):**  
- [US 97 – Progress Page: Failing contrast on passing grade text](https://projects.arbisoft.com/project/zaraahmed-tutor-indigo-accessibility/us/97)

---

### 🧪 How Has This Been Tested?

- Verified contrast ratio using WCAG-compliant color contrast tools.
- Confirmed visibility in both light and dark themes across various zoom levels.

---

### 🖼️ Screenshots/Sandbox

**Live Preview:** [Demo Course – Progress](https://apps.sandbox.openedx.edly.io/courses/course-v1:edX+DemoX+Demo_Course/progress)

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/99b500c4-ac49-44b7-98aa-29cffe441fa3) | ![image](https://github.com/user-attachments/assets/a1947d72-c373-4aa4-ab7e-266649ec1510) |

---

## 🔗 Related

* **Related GitHub Issue:** [tutor-indigo/#146 – Accessibility compliance](https://github.com/overhangio/tutor-indigo/issues/146)
