### PR TITLE
fix: make 'skip to content' consistent

### DIFF
--- a/paragon/_discussion.scss
+++ b/paragon/_discussion.scss
@@ -1,6 +1,7 @@
 // Discussion style
 
-#root #courseTabsNavigation {
+#root {
+  #courseTabsNavigation {
     padding: 20px 15px !important;
     max-width: 1600px;
     margin: 0 auto;
@@ -14,6 +15,13 @@
             margin: 0 !important;
         }
     }
+  }
+
+  &:has(.header-action-bar) {
+    .sr-only.sr-only-focusable {
+      display: none;
+    }
+  }
 }
 #root .header-action-bar {
 max-width: 1600px;

--- a/paragon/_header.scss
+++ b/paragon/_header.scss
@@ -3,6 +3,27 @@
     position: relative;
     z-index: 1;
     width: 100%;
+
+    header {
+      .sr-only-focusable {
+        z-index: 9999;
+        position: absolute;
+        top: 5px;
+        left: 50%;
+        background-color: black;
+        opacity: 0.8;
+        color: white;
+        text-decoration: none;
+        outline: none;
+        transform: translateX(-50%);
+        font-size: 1rem;
+        padding: 0 5px;
+
+        &:focus {
+          clip: auto;
+        }
+      }
+    }
     header.site-header-mobile {
         padding: 0 15px;
         height: auto;
@@ -133,9 +154,13 @@
             .nav-link:focus,
             .nav-link.active,
             .expanded .nav-link {
-            background: transparent;
-            color: $primary;
-            text-decoration: underline;
+              background: transparent;
+              color: $primary;
+              text-decoration: underline;
+            }
+
+            .dropdown-divider {
+                display: none;
             }
         }
         .logo {


### PR DESCRIPTION
## Description
This PR makes the **"Skip to content"** link styling to ensure a consistent and accessible experience across all pages.  
The update applies unified SCSS rules for the `.sr-only-focusable` class within the `header` element, ensuring the link is:

- Positioned consistently at the top center of the page  
- Clearly visible on focus with high contrast (black background, white text)  
- Readable and easily accessible for keyboard users  
 
**Taiga Task (if you have access):**  
- [Skip to main content](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/43)

---

## Screenshots
| Before | After |
| :--- | :---: |
| <img width="1620" height="654" alt="image" src="https://github.com/user-attachments/assets/956cf99e-1ccc-4d95-a0ae-b50dd5749f59" /> | <img width="3022" height="596" alt="image" src="https://github.com/user-attachments/assets/900b9f80-98cc-4aad-93c0-067e43d67538" /> |