### PR TITLE
Fixes to get token colour definitions to work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "description": "The default branding and SASS theme package containing for Open edX applications. This package is designed to be copied and customized.",
   "scripts": {
-    "build-tokens": "paragon build-tokens --source ./paragon/tokens/ --build-dir ./paragon/build -t git  -t dark",
-    "build-scss": "paragon build-scss --corePath ./paragon/core.scss --themesPath ./paragon/build/themes --source",
+    "build-tokens": "paragon build-tokens --source ./paragon/tokens/src/ --build-dir ./paragon/build",
+    "build-scss": "paragon build-scss --corePath ./paragon/core.scss --themesPath ./paragon/build/themes",
     "build": "make build",
     "build:watch": "nodemon --ignore dist -x \"make build\"",
+    "serve": "paragon serve-theme-css --host 0.0.0.0",
     "paragon:help": "paragon help"
   },
   "repository": {

--- a/paragon/_account.scss
+++ b/paragon/_account.scss
@@ -58,7 +58,7 @@
                         &.font-weight-bold {
                             a {
                                 background: var(--pgn-color-primary-light, #F2F7F8);
-                                color: var(--pgn-color-primary, #15376D);
+                                color: var(--pgn-color-primary-base, #15376D);
                                 text-decoration: none;
                             }
                         }
@@ -67,13 +67,13 @@
                             font-size: 14px;
                             font-weight: 500;
                             line-height: 20px;
-                            color: var(--pgn-color-primary, #15376D);
+                            color: var(--pgn-color-primary-base, #15376D);
                             text-decoration: none;
                             padding: 8px 12px;
                             border-radius: 6px;
                             &:hover {
                                 background: var(--pgn-color-primary-light, #F2F7F8);
-                                color: var(--pgn-color-primary, #15376D);
+                                color: var(--pgn-color-primary-base, #15376D);
                                 text-decoration: none;
                             }
                         }
@@ -102,7 +102,7 @@
             font-size: 14px;
         }
         a.standalone-link {
-            color: var(--pgn-color-primary, #15376D);
+            color: var(--pgn-color-primary-base, #15376D);
         }
         button.btn-outline-danger {
             padding: 7px 13px !important;
@@ -133,7 +133,7 @@
                 &.btn-link {
                     font-weight: 600;
                     font-size: 16px;
-                    color: var(--pgn-color-primary, #15376D);
+                    color: var(--pgn-color-primary-base, #15376D);
                 }
             }
         }
@@ -143,7 +143,7 @@
             padding: 15px !important;
             background: var(--pgn-color-primary-light, #F2F7F8) !important;
             a {
-                color: var(--pgn-color-primary, #15376D);
+                color: var(--pgn-color-primary-base, #15376D);
             }
         }
     }
@@ -183,7 +183,7 @@
                 button {
                     font-weight: 600;
                     font-size: 16px;
-                    color: var(--pgn-color-primary, #15376D);
+                    color: var(--pgn-color-primary-base, #15376D);
                     margin: 0 !important;
                 }
             }
@@ -198,7 +198,7 @@
                 }
                 button {
                     padding: 7px 13px !important;
-                    border: 1px solid var(--pgn-color-primary, #15376D) !important;
+                    border: 1px solid var(--pgn-color-primary-base, #15376D) !important;
                     color: #fff;
                     text-decoration: none;
                     font-size: 14px;
@@ -208,7 +208,7 @@
                     position: absolute;
                     right: 15px;
                     top: 15px;
-                    background: var(--pgn-color-primary, #15376D);
+                    background: var(--pgn-color-primary-base, #15376D);
                     svg {
                         display: none;
                     }
@@ -240,14 +240,14 @@
                 margin: 0;
                 button {
                     padding: 7px 13px !important;
-                    border: 1px solid var(--pgn-color-primary, #15376D) !important;
+                    border: 1px solid var(--pgn-color-primary-base, #15376D) !important;
                     color: #fff;
                     text-decoration: none;
                     font-size: 14px;
                     font-weight: 500;
                     line-height: 20px;
                     margin: 0 0 0 15px !important;
-                    background: var(--pgn-color-primary, #15376D);
+                    background: var(--pgn-color-primary-base, #15376D);
                     border-radius: 8px;
                     &.btn-outline-primary {
                         background: #fff !important;

--- a/paragon/_account.scss
+++ b/paragon/_account.scss
@@ -89,7 +89,7 @@
                 max-width: 500px;
                 padding: 0 0 0 50px;
             }
-            @media (--pgn-size-breakpoint-max-width-lg) {
+            @media (--pgn-size-breakpoint-min-width-lg) {
                 flex: 750px;
                 max-width: 750px;
             }

--- a/paragon/_dark.scss
+++ b/paragon/_dark.scss
@@ -20,7 +20,7 @@ body.indigo-dark-theme {
     color: var(--pgn-color-text) !important;
     background: var(--pgn-color-background) !important;
     * {
-        accent-color: var(--pgn-color-primary);
+        accent-color: var(--pgn-color-primary-base);
     }
 }
 

--- a/paragon/_dates.scss
+++ b/paragon/_dates.scss
@@ -20,14 +20,14 @@ div[role=heading].h2 + .list-unstyled.m-0.mt-4.pt-2 {
                         border: 2px solid  #D1D5DB !important;
                     }
                     &.bg-warning-300 {
-                        border: 2px solid  var(--pgn-color-primary, #15376D) !important;
+                        border: 2px solid  var(--pgn-color-primary-base, #15376D) !important;
                         background: white !important;
                         &:after {
                             position: absolute;
                             left: 50%;
                             top: 50%;
                             content: "";
-                            background: var(--pgn-color-primary, #15376D);
+                            background: var(--pgn-color-primary-base, #15376D);
                             border-radius: 50%;
                             width: 10px;
                             height: 10px;
@@ -71,13 +71,13 @@ div[role=heading].h2 + .list-unstyled.m-0.mt-4.pt-2 {
         &:first-child {
             &.dates-day.pb-4 {
                 .dates-line-bottom {
-                    border-color: var(--pgn-color-primary, #15376D) !important;
+                    border-color: var(--pgn-color-primary-base, #15376D) !important;
                 }
                 .dates-dot {
                     &.border {
                         &.border-gray-900 {
-                            background: var(--pgn-color-primary, #15376D) !important;
-                            border: 2px solid  var(--pgn-color-primary, #15376D) !important;
+                            background: var(--pgn-color-primary-base, #15376D) !important;
+                            border: 2px solid  var(--pgn-color-primary-base, #15376D) !important;
                             &:before {
                                 position: absolute;
                                 top: 50%;
@@ -92,7 +92,7 @@ div[role=heading].h2 + .list-unstyled.m-0.mt-4.pt-2 {
                             }
                         }
                         &.bg-warning-300 {
-                            border: 2px solid  var(--pgn-color-primary, #15376D) !important;
+                            border: 2px solid  var(--pgn-color-primary-base, #15376D) !important;
                             background: white !important;
                             &:before {
                                 display: none !important;
@@ -107,8 +107,8 @@ div[role=heading].h2 + .list-unstyled.m-0.mt-4.pt-2 {
                 .dates-dot {
                     &.border {
                         &.border-gray-900 {
-                            background: var(--pgn-color-primary, #15376D) !important;
-                            border: 2px solid  var(--pgn-color-primary, #15376D) !important;
+                            background: var(--pgn-color-primary-base, #15376D) !important;
+                            border: 2px solid  var(--pgn-color-primary-base, #15376D) !important;
                             &:before {
                                 position: absolute;
                                 top: 50%;
@@ -123,7 +123,7 @@ div[role=heading].h2 + .list-unstyled.m-0.mt-4.pt-2 {
                             }
                         }
                         &.bg-warning-300 {
-                            border: 2px solid  var(--pgn-color-primary, #15376D) !important;
+                            border: 2px solid  var(--pgn-color-primary-base, #15376D) !important;
                             background: white !important;
                             &:before {
                                 display: none !important;

--- a/paragon/_discussion.scss
+++ b/paragon/_discussion.scss
@@ -56,7 +56,7 @@ position: static;
             background: var(--pgn-color-primary-light, #F2F7F8) !important;
         }
         &.active {
-            background: var(--pgn-color-primary, #15376D) !important;
+            background: var(--pgn-color-primary-base, #15376D) !important;
         }
         }
 
@@ -71,7 +71,7 @@ position: static;
     line-height: 22px;
     font-weight: 500;
     border-radius: 6px;
-    background: var(--pgn-color-primary, #15376D);
+    background: var(--pgn-color-primary-base, #15376D);
     margin: 0 0 0 12px;
     white-space: nowrap;
     }
@@ -209,8 +209,8 @@ width: 100%;
 }
 .masquerade-bar  {
     .btn-brand {
-        background: var(--pgn-color-primary, #15376D);
-        border-color: var(--pgn-color-primary, #15376D);
+        background: var(--pgn-color-primary-base, #15376D);
+        border-color: var(--pgn-color-primary-base, #15376D);
     }
 }
 div[data-learner-type=b2c_learner] div[role=heading].h2, div[role=heading].h2 {

--- a/paragon/_extras.scss
+++ b/paragon/_extras.scss
@@ -7,7 +7,7 @@
 
     .light-theme-icon > span, .dark-theme-icon > span{
         width: 18px;
-        color: var(--pgn-color-primary, #15376D);
+        color: var(--pgn-color-primary-base, #15376D);
     }
 
     .toggle-switch {

--- a/paragon/_footer.scss
+++ b/paragon/_footer.scss
@@ -11,7 +11,7 @@ footer.tutor-container {
     padding: 0 15px;
     max-width: 1600px;
     text-align: center;
-    @media (--pgn-size-breakpoint-max-width-lg) {
+    @media (--pgn-size-breakpoint-min-width-lg) {
         text-align: left;
     }
     .footer-top {
@@ -26,7 +26,7 @@ footer.tutor-container {
             @media (--pgn-size-breakpoint-min-width-md) {
                 margin: 0 0 15px;
             }
-            @media (--pgn-size-breakpoint-max-width-lg) {
+            @media (--pgn-size-breakpoint-min-width-lg) {
                 float: left;
             }
         }
@@ -108,7 +108,7 @@ footer.tutor-container {
 #dashboard-container {
     padding: 0 !important;
     #dashboard-content {
-        @media (--pgn-size-breakpoint-max-width-lg) {
+        @media (--pgn-size-breakpoint-min-width-lg) {
           min-height: calc(100vh - 232px);
         }
     }
@@ -121,7 +121,7 @@ footer.tutor-container {
                 flex: 0 0 100%;
                 max-width: 100%;
                 padding: 0 15px;
-                @media (--pgn-size-breakpoint-max-width-lg) {
+                @media (--pgn-size-breakpoint-min-width-lg) {
                     flex: 0 0 70%;
                     max-width: 70%;
                 }
@@ -349,7 +349,7 @@ footer.tutor-container {
                 flex: 0 0 100%;
                 max-width: 100%;
                 padding: 0 15px;
-                @media (--pgn-size-breakpoint-max-width-lg) {
+                @media (--pgn-size-breakpoint-min-width-lg) {
                     flex: 0 0 30%;
                     max-width: 30%;
                     padding: 80px 15px 0;
@@ -362,7 +362,7 @@ footer.tutor-container {
                     #looking-for-challenge-widget {
                         padding: 0 !important;
                         box-shadow: none !important;
-                        @media (--pgn-size-breakpoint-max-width-lg) {
+                        @media (--pgn-size-breakpoint-min-width-lg) {
                             padding: 0 0 0 25px !important;
                         }
                         .pgn__card-wrapper-image-cap {

--- a/paragon/_footer.scss
+++ b/paragon/_footer.scss
@@ -376,13 +376,13 @@ footer.tutor-container {
                                 margin: 0 0 8px;
                             }
                             a {
-                                color: var(--pgn-color-primary, #15376D);
+                                color: var(--pgn-color-primary-base, #15376D);
                                 font-size: 12px;
                                 line-height: 18px;
                                 font-weight: 500;
                                 svg {
                                     width: 18px;
-                                    fill: var(--pgn-color-primary, #15376D);
+                                    fill: var(--pgn-color-primary-base, #15376D);
                                 }
                             }
                         }
@@ -413,8 +413,8 @@ footer.tutor-container {
         margin: 0 0 27px;
     }
     a.btn-brand {
-        background: var(--pgn-color-primary, #15376D);
-        border-color: var(--pgn-color-primary, #15376D);
+        background: var(--pgn-color-primary-base, #15376D);
+        border-color: var(--pgn-color-primary-base, #15376D);
         margin: 0;
         font-size: 14px;
         font-weight: 500;
@@ -432,7 +432,7 @@ footer.tutor-container {
 #course-list-active-filters {
     margin-bottom: 10px;
     .pgn__chip.pgn__chip-light {
-        background: var(--pgn-color-primary, #15376D);
+        background: var(--pgn-color-primary-base, #15376D);
         * {
             color: white;
             fill: white;

--- a/paragon/_header.scss
+++ b/paragon/_header.scss
@@ -82,7 +82,7 @@
                 border-radius: 0;
                 box-shadow: none;
                 border: none !important;
-                border-bottom: 2px solid var(--pgn-color-primary, #15376D) !important;
+                border-bottom: 2px solid var(--pgn-color-primary-base, #15376D) !important;
                 overflow: hidden;
                 inset: unset !important;
                 transform: none !important;
@@ -134,7 +134,7 @@
             .nav-link.active,
             .expanded .nav-link {
             background: transparent;
-            color: var(--pgn-color-primary, #15376D);
+            color: var(--pgn-color-primary-base, #15376D);
             text-decoration: underline;
             }
         }
@@ -163,7 +163,7 @@
                 &:hover {
                     color: var(--pgn-color-text, #111827);
                     text-decoration: none;
-                    border-bottom: 2px solid var(--pgn-color-primary, #15376D);
+                    border-bottom: 2px solid var(--pgn-color-primary-base, #15376D);
                 }
             }
         }
@@ -173,8 +173,8 @@
                 padding: 9px 15px !important;
                 box-shadow: none !important;
                 outline: none !important;
-                background: var(--pgn-color-primary, #15376D)-light !important;
-                color: var(--pgn-color-primary, #15376D);
+                background: var(--pgn-color-primary-base, #15376D)-light !important;
+                color: var(--pgn-color-primary-base, #15376D);
                 font-size: 14px;
                 font-weight: 500;
                 line-height: 20px;
@@ -186,7 +186,7 @@
                     vertical-align: middle;
                     content: "";
                     margin: 0 0 2px 8px;
-                    border: 2px solid var(--pgn-color-primary, #15376D);
+                    border: 2px solid var(--pgn-color-primary-base, #15376D);
                     border-width: 0 0 2px 2px;
                     transform: rotate(-45deg);
                     width: 7px;
@@ -263,7 +263,7 @@
                     &.active, &:hover {
                         color: var(--pgn-color-text, #111827);
                         text-decoration: none;
-                        border-bottom: 2px solid var(--pgn-color-primary, #15376D);
+                        border-bottom: 2px solid var(--pgn-color-primary-base, #15376D);
                     }
                 }
             }
@@ -321,8 +321,8 @@
             padding: 9px 15px !important;
             box-shadow: none !important;
             outline: none !important;
-            background: var(--pgn-color-primary, #15376D)-light !important;
-            color: var(--pgn-color-primary, #15376D);
+            background: var(--pgn-color-primary-base, #15376D)-light !important;
+            color: var(--pgn-color-primary-base, #15376D);
             font-size: 14px;
             font-weight: 500;
             line-height: 20px;
@@ -335,7 +335,7 @@
                 display: none;
             }
             &:after {
-                border-color: var(--pgn-color-primary, #15376D) !important;
+                border-color: var(--pgn-color-primary-base, #15376D) !important;
                 margin-left: 8px !important;
                 @media (--pgn-size-breakpoint-max-width-md) {
                     display: none;
@@ -407,7 +407,7 @@
                 width: 100%;
                 margin: 26px 0 0 !important;
                 border: none !important;
-                border-bottom: 2px solid var(--pgn-color-primary, #15376D) !important;
+                border-bottom: 2px solid var(--pgn-color-primary-base, #15376D) !important;
                 box-shadow: none;
                 border-radius: 0;
             }
@@ -422,7 +422,7 @@
                     padding: 16px;
                 }
                 &:hover {
-                    background: var(--pgn-color-primary, #15376D)-light;
+                    background: var(--pgn-color-primary-base, #15376D)-light;
                     color: var(--pgn-color-text, #111827);                         ;
                 }
                 &.h-desktop {
@@ -482,7 +482,7 @@
             &.course-link, &:hover {
                 color: var(--pgn-color-text, #111827);
                 text-decoration: none;
-                border-bottom: 2px solid var(--pgn-color-primary, #15376D) !important;
+                border-bottom: 2px solid var(--pgn-color-primary-base, #15376D) !important;
             }
         }
         .btn-icon.btn-icon-inverse-primary {
@@ -502,7 +502,7 @@
 }
 #root {
     .nav-small-menu {
-        border-bottom: 2px solid var(--pgn-color-primary, #15376D) !important;
+        border-bottom: 2px solid var(--pgn-color-primary-base, #15376D) !important;
         box-shadow: none !important;
         width: 100%;
         position: absolute;

--- a/paragon/_header.scss
+++ b/paragon/_header.scss
@@ -142,7 +142,7 @@
             position: static;
             height: auto;
             margin: 15px 0 15px 35px !important;
-            @media (--pgn-size-breakpoint-max-width-lg) {
+            @media (--pgn-size-breakpoint-min-width-lg) {
                 margin: 0 18px 0 0 !important;
             }
             img {
@@ -237,7 +237,7 @@
             position: static;
             height: auto;
             margin: 15px 0 15px 35px !important;
-            @media (--pgn-size-breakpoint-max-width-lg) {
+            @media (--pgn-size-breakpoint-min-width-lg) {
                 margin: 0 18px 0 0 !important;
             }
             img {
@@ -248,7 +248,7 @@
             display: flex;
             .nav-course {
                 display: none;
-                @media (--pgn-size-breakpoint-max-width-lg) {
+                @media (--pgn-size-breakpoint-min-width-lg) {
                     display: block;
                 }
                 a {

--- a/paragon/_learning.scss
+++ b/paragon/_learning.scss
@@ -23,7 +23,7 @@
             }
         }
         .text-success {
-            color: var(--pgn-color-primary, #15376D) !important;
+            color: var(--pgn-color-primary-base, #15376D) !important;
         }
         .align-middle.col-6 {
             padding-left: 0;
@@ -46,7 +46,7 @@
             padding: 0 0 0 91px;
         }
         .text-success {
-            color: var(--pgn-color-primary, #15376D) !important;
+            color: var(--pgn-color-primary-base, #15376D) !important;
         }
         ol {
             padding: 0 0 15px;
@@ -110,7 +110,7 @@
                     margin-left: 0;
                 }
                 a {
-                    background: var(--pgn-color-primary, #15376D);
+                    background: var(--pgn-color-primary-base, #15376D);
                     padding: 9px 17px;
                     font-size: 16px;
                     line-height: 24px;
@@ -145,7 +145,7 @@
 }
 #root .course-outline-tab .col-12.col-md-auto.p-0 .btn {
     background: none !important;
-    color: var(--pgn-color-primary, #15376D) !important;
+    color: var(--pgn-color-primary-base, #15376D) !important;
 }
 .course-tabs-navigation {
     padding-top: 20px;
@@ -201,7 +201,7 @@ div[data-learner-type=b2c_learner] {
                     font-size: 14px;
                     line-height: 20px;
                     font-weight: 500;
-                    color: var(--pgn-color-primary, #15376D);
+                    color: var(--pgn-color-primary-base, #15376D);
                     text-decoration: underline;
                     &:hover {
                         text-decoration: none;
@@ -217,7 +217,7 @@ div[data-learner-type=b2c_learner] {
 #courseHome-dates {
     a {
         &:hover {
-            color: var(--pgn-color-primary, #15376D);
+            color: var(--pgn-color-primary-base, #15376D);
         }
     }
     .small {

--- a/paragon/_login.scss
+++ b/paragon/_login.scss
@@ -57,7 +57,7 @@
                 max-width: 564px !important;
                 font-size: 32px;
                 line-height: 40px;
-                color: var(--pgn-color-primary, #15376D) !important;
+                color: var(--pgn-color-primary-base, #15376D) !important;
                 padding: 50px 0;
                 position: relative;
                 z-index: 1;
@@ -74,7 +74,7 @@
                     font-weight: 400;
                     font-size: 34px;
                     line-height: 40px;
-                    color: var(--pgn-color-primary, #15376D) !important;
+                    color: var(--pgn-color-primary-base, #15376D) !important;
                     display: block !important;
                     font-weight: 900;
                     @media (--pgn-size-breakpoint-min-width-sm) {
@@ -117,8 +117,8 @@
                         display: none;
                     }
                     &.active, &:hover {
-                        color: var(--pgn-color-primary, #15376D);
-                        border-bottom: 2px solid var(--pgn-color-primary, #15376D);
+                        color: var(--pgn-color-primary-base, #15376D);
+                        border-bottom: 2px solid var(--pgn-color-primary-base, #15376D);
                     }
                 }
             }
@@ -153,8 +153,8 @@
                     font-size: 14px;
                 }
                 .btn-brand {
-                    background-color: var(--pgn-color-primary, #15376D);
-                    border-color: var(--pgn-color-primary, #15376D);
+                    background-color: var(--pgn-color-primary-base, #15376D);
+                    border-color: var(--pgn-color-primary-base, #15376D);
                     font-size: 14px;
                     font-weight: 500;
                     line-height: 30px;

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -269,17 +269,17 @@ html {
                         border-top: none;
                         &.complete {
                             background: var(--pgn-color-primary-light, #F2F7F8);
-                            color: var(--pgn-color-primary, #15376D);
+                            color: var(--pgn-color-primary-base, #15376D);
                             &:after {
                                 background: var(--pgn-color-primary-light, #F2F7F8) !important;
                             }
                             &.active {
                                 &:after {
-                                    background: var(--pgn-color-primary, #15376D) !important;
+                                    background: var(--pgn-color-primary-base, #15376D) !important;
                                 }
                             }
                             .text-success {
-                                color: var(--pgn-color-primary, #15376D) !important;
+                                color: var(--pgn-color-primary-base, #15376D) !important;
                             }
                         }
                     }
@@ -404,4 +404,4 @@ html {
 
 
 // Including dark theme
-@import "./dark";
+// @import "./dark"; // Temporarily commented out to avoid dark theme issues

--- a/paragon/_profile.scss
+++ b/paragon/_profile.scss
@@ -1,6 +1,6 @@
 // profile page style
 .profile-page {
-    @media (--pgn-size-breakpoint-max-width-lg) {
+    @media (--pgn-size-breakpoint-min-width-lg) {
         min-height: calc(100vh - 142px);
     }
     .form-control {
@@ -95,7 +95,7 @@
                     flex: 0 0 50% !important;
                     max-width: 50% !important;
                 }
-                @media (--pgn-size-breakpoint-max-width-lg) {
+                @media (--pgn-size-breakpoint-min-width-lg) {
                     padding: 50px 50px 30px 15px !important;
                 }
                 .d-none.d-md-block {
@@ -108,7 +108,7 @@
                 @media (--pgn-size-breakpoint-min-width-md) {
                     padding: 50px 15px 30px 15px !important;
                 }
-                @media (--pgn-size-breakpoint-max-width-lg) {
+                @media (--pgn-size-breakpoint-min-width-lg) {
                     padding: 50px 15px 30px 50px !important;
                 }
                 .alert-content {

--- a/paragon/_profile.scss
+++ b/paragon/_profile.scss
@@ -121,7 +121,7 @@
                     font-size: 14px;
                     line-height: 20px;
                     a {
-                        color: var(--pgn-color-primary, #15376D);
+                        color: var(--pgn-color-primary-base, #15376D);
                     }
                     .alert-heading.h4 {
                         margin: 0 0 10px;
@@ -164,13 +164,13 @@
                         padding: 15px;
                         a.default-link {
                             padding: 7px 13px !important;
-                            border: 1px solid var(--pgn-color-primary, #15376D) !important;
-                            color: var(--pgn-color-primary, #15376D);
+                            border: 1px solid var(--pgn-color-primary-base, #15376D) !important;
+                            color: var(--pgn-color-primary-base, #15376D);
                             text-decoration: none;
                             font-size: 0;
                             line-height: 0;
                             margin: 0 !important;
-                            background: var(--pgn-color-primary, #15376D);
+                            background: var(--pgn-color-primary-base, #15376D);
                             position: absolute;
                             top: 15px;
                             right: 15px;
@@ -234,7 +234,7 @@
                     margin: 0 !important;
                     button {
                         padding: 7px 13px !important;
-                        border: 1px solid var(--pgn-color-primary, #15376D) !important;
+                        border: 1px solid var(--pgn-color-primary-base, #15376D) !important;
                         color: #fff;
                         text-decoration: none;
                         font-size: 14px;
@@ -244,7 +244,7 @@
                         position: absolute;
                         right: 15px;
                         top: 15px;
-                        background: var(--pgn-color-primary, #15376D);
+                        background: var(--pgn-color-primary-base, #15376D);
                         svg {
                             display: none;
                         }
@@ -299,14 +299,14 @@
                                 line-height: 20px;
                                 border: none !important;
                                 padding: 0 !important;
-                                color: var(--pgn-color-primary, #15376D) !important;
+                                color: var(--pgn-color-primary-base, #15376D) !important;
                                 text-decoration: underline;
                                 &:after {
                                     display: none;
                                 }
                             }
                             a {
-                                color: var(--pgn-color-primary, #15376D);
+                                color: var(--pgn-color-primary-base, #15376D);
                                 font-size: 16px;
                                 font-weight: 600;
                                 line-height: 20px;
@@ -344,14 +344,14 @@
                         margin: 0;
                         button {
                             padding: 7px 13px !important;
-                            border: 1px solid var(--pgn-color-primary, #15376D) !important;
+                            border: 1px solid var(--pgn-color-primary-base, #15376D) !important;
                             color: #fff;
                             text-decoration: none;
                             font-size: 14px;
                             font-weight: 500;
                             line-height: 20px;
                             margin: 0 0 0 15px !important;
-                            background: var(--pgn-color-primary, #15376D);
+                            background: var(--pgn-color-primary-base, #15376D);
                             &.btn-link {
                                 background: #fff !important;
                                 border-color: #D1D5DB !important;
@@ -368,7 +368,7 @@
     }
     .profile-avatar {
         svg.text-muted {
-            color: var(--pgn-color-primary, #15376D) !important;
+            color: var(--pgn-color-primary-base, #15376D) !important;
         }
     }
 }

--- a/paragon/_progress.scss
+++ b/paragon/_progress.scss
@@ -39,11 +39,11 @@
                     background: var(--pgn-color-primary-light, #F2F7F8) !important;
                     .h4 {
                         font-size: 14px;
-                        color: var(--pgn-color-primary, #15376D);
+                        color: var(--pgn-color-primary-base, #15376D);
                         font-weight: 600;
                     }
                     svg {
-                        color: var(--pgn-color-primary, #15376D);
+                        color: var(--pgn-color-primary-base, #15376D);
                     }
                 }
             }
@@ -86,14 +86,14 @@
                 ul {
                     list-style: none;
                     a {
-                        color: var(--pgn-color-primary, #15376D);
+                        color: var(--pgn-color-primary-base, #15376D);
                     }
                 }
             }
         }
     }
     .donut-ring.complete-stroke, .donut-segment.complete-stroke, .donut-hole.complete-stroke {
-        stroke: var(--pgn-color-primary, #15376D);
+        stroke: var(--pgn-color-primary-base, #15376D);
     }
     .donut-ring.incomplete-stroke, .donut-segment.incomplete-stroke, .donut-hole.incomplete-stroke {
         stroke: var(--pgn-color-primary-light, #F2F7F8);
@@ -144,7 +144,7 @@
                 font-size: 14px !important;
             }
             #weighted-grade-summary.small {
-                color: var(--pgn-color-primary, #15376D) !important;
+                color: var(--pgn-color-primary-base, #15376D) !important;
                 font-weight: 600 !important;
                 font-size: 14px !important;
             }
@@ -152,15 +152,15 @@
     }
 }
 #non-passing-grade-tooltip {
-    background: var(--pgn-color-primary, #15376D);
-    border-color: var(--pgn-color-primary, #15376D);
+    background: var(--pgn-color-primary-base, #15376D);
+    border-color: var(--pgn-color-primary-base, #15376D);
     filter: none;
     .arrow {
         &:before {
-            border-top-color: var(--pgn-color-primary, #15376D) !important;
+            border-top-color: var(--pgn-color-primary-base, #15376D) !important;
         }
         &:after {
-            border-top-color: var(--pgn-color-primary, #15376D) !important;
+            border-top-color: var(--pgn-color-primary-base, #15376D) !important;
         }
     }
     .popover-body {

--- a/paragon/_tour.scss
+++ b/paragon/_tour.scss
@@ -11,12 +11,12 @@
             max-width: 100% !important;
         }
         h2.pgn__modal-title {
-            color: var(--pgn-color-primary, #15376D) !important;
+            color: var(--pgn-color-primary-base, #15376D) !important;
             font-size: 27px;
             line-height: 30px;
             margin: 0;
             .text-accent-b {
-                color: var(--pgn-color-primary, #15376D) !important;
+                color: var(--pgn-color-primary-base, #15376D) !important;
             }
         }
     }
@@ -42,15 +42,15 @@
             border: 1px solid #D1D5DB;
             margin: 0 10px;
             &.btn-brand {
-                background: var(--pgn-color-primary, #15376D) !important;
-                border-color: var(--pgn-color-primary, #15376D) !important;
+                background: var(--pgn-color-primary-base, #15376D) !important;
+                border-color: var(--pgn-color-primary-base, #15376D) !important;
             }
         }
     }
 }
 #pgn__checkpoint {
     background: var(--pgn-color-primary-light, #F2F7F8);
-    border-top: 8px solid var(--pgn-color-primary, #15376D);
+    border-top: 8px solid var(--pgn-color-primary-base, #15376D);
     #pgn__checkpoint-title {
         font-size: 22px;
         line-height: 30px;
@@ -58,7 +58,7 @@
     }
 }
 #pgn__checkpoint[data-popper-placement^=bottom] > #pgn__checkpoint-arrow:after {
-    border-bottom: solid 15px var(--pgn-color-primary, #15376D);
+    border-bottom: solid 15px var(--pgn-color-primary-base, #15376D);
 }
 #pgn__checkpoint[data-popper-placement^=top] > #pgn__checkpoint-arrow:after {
     border-top: solid 15px var(--pgn-color-primary-light, #F2F7F8);

--- a/paragon/core.scss
+++ b/paragon/core.scss
@@ -5,4 +5,4 @@
 
 @import "./variables";
 @import "./header";
-@import "./overrides"; // Temporarily commented out to avoid dark theme issues
+@import "./overrides";

--- a/paragon/tokens/src/themes/light/color/brand.json
+++ b/paragon/tokens/src/themes/light/color/brand.json
@@ -1,19 +1,12 @@
 {
-  "brand": {
+  "$type": "color",
+  "color": {
     "primary": {
-      "$value": "#15376D"
-    },
-    "primary-light": {
-      "$value": "#F2F7F8"
-    },
-    "text": {
-      "$value": "#111827"
-    },
-    "text-primary": {
-      "$value": "#515661"
-    },
-    "text-light": {
-      "$value": "#515661"
+      "base": {
+        "$value": "#00ff00",
+        "source": "$primary",
+        "$description": "Basic primary color."
+      }
     }
   }
 }


### PR DESCRIPTION
* Fix the path in the `build-tokens` script so that tokens are processed;
* Fix the structure of the token file so that colour definitions are taken into account;
* Change the usage of the `--pgn-color-primary` variable to `--pgn-color-primary-base` so that the variables defined by the token file have an effect.

I think if the SCSS variables were replaced with the `paragon replace-variables` command instead of manually, with an adequate token file, it would have been automatic (`color.primary.base` has `"source": "$primary"`, so `$primary` would be replaced by `--pgn-color-primary-base`.)