### PR TITLE
feat: set EDL primary/secondary brand colors

### DIFF
--- a/paragon/tokens/themes/light/global/color.json
+++ b/paragon/tokens/themes/light/global/color.json
@@ -1,0 +1,17 @@
+{
+  "color": {
+    "$type": "color",
+    "primary": {
+      "base": {
+        "$value": "#000000",
+        "$description": "EDL primary brand color (black)."
+      }
+    },
+    "secondary": {
+      "base": {
+        "$value": "#9b51e0",
+        "$description": "EDL secondary brand color (purple)."
+      }
+    }
+  }
+}


### PR DESCRIPTION
Override Paragon color tokens for the light theme so all MFEs that consume this brand package render EDL's primary (#000000) and secondary (#9b51e0) across buttons, links, and accents.

Only the base tokens are overridden; Paragon generates the 100-900 shade scale by mixing with white/black at build time.